### PR TITLE
学習ログで改行をした際に・を各行の先頭に付けて返す実装

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -69,7 +69,8 @@
           id="submit-btn"
           class="btn_green btn_green_short"
           type="submit"
-          value="学習記録を投稿する"
+          value="学習記録を投稿する(200字以内)"
+          maxlength="200"
         />
       </form>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,7 +97,7 @@
   const submitBtn = document.querySelector("#submit-btn");
 
   submitBtn.addEventListener("click", () => {
-    const lines = input.value.split("\n");
+    const lines = textValue.split("\n");
     const updatedLines = lines.map((line) => {
       if (line.startsWith("・")) {
         return line;
@@ -106,7 +106,6 @@
       }
     });
     textValue = updatedLines.join("\n");
-    console.log(textValue);
   });
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,7 @@
           name="post"
         ></textarea>
         <input
+          id="submit-btn"
           class="btn_green btn_green_short"
           type="submit"
           value="学習記録を投稿する"
@@ -82,14 +83,31 @@
       <button id="withdrawal-btn">退会する</button>
     </div>
   </div>
-    </div>
-    {% include 'modal/goal.html' %} {% include 'modal/quit.html' %}
-  </div>
-  {% endblock %} {% block script %}
-  <script
-    src="{{url_for('static',filename='js/modal.js')}}"
-    type="text/javascript"
-  ></script>
-  {% endblock %} <<<<<<< HEAD ======= {% block script %} {% endblock %} >>>>>>>
-  c30bba1367cbac88eb375d03e58fcd87ee3124a0
 </div>
+{% include 'modal/goal.html' %} {% include 'modal/quit.html' %} {% endblock %}
+{% block script %}
+<script
+  src="{{url_for('static',filename='js/modal.js')}}"
+  type="text/javascript"
+></script>
+<script>
+  let input = document.querySelector(".study_log");
+  let textValue = input.value;
+  const submitBtn = document.querySelector("#submit-btn");
+
+  submitBtn.addEventListener("click", () => {
+    console.log(textValue);
+    const lines = input.value.split("\n");
+    const updatedLines = lines.map((line) => {
+      if (line.startsWith("・")) {
+        return line;
+      } else {
+        return "・" + line;
+      }
+    });
+    console.log(updatedLines);
+    textValue = updatedLines.join("\n");
+    console.log(textValue);
+  });
+</script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,7 +97,6 @@
   const submitBtn = document.querySelector("#submit-btn");
 
   submitBtn.addEventListener("click", () => {
-    console.log(textValue);
     const lines = input.value.split("\n");
     const updatedLines = lines.map((line) => {
       if (line.startsWith("・")) {
@@ -106,7 +105,6 @@
         return "・" + line;
       }
     });
-    console.log(updatedLines);
     textValue = updatedLines.join("\n");
     console.log(textValue);
   });


### PR DESCRIPTION
■実装内容
学習記録の以下要件を満たすよう実装
・学習記録の内容を入力し登録ボタンを押した際に、各先頭行に・を置きリスト化のように表示できるように実装
・学習記録をコンパクト化する為に文字数制限を設けるとのことだったので、maxlengthをtextareaに指定
・HTMLのコードも一部最後の箇所おかしい部分（コンフリの残骸や閉じタグの位置等）があったので修正

■注意点
・本jsの実装では、値を取り出して一行ごとに分割し、そこから・を1回だけつける(既についていればそのままreturn)、それをtextareaに入れ替える処理を走らせている
・本機能はローカル環境では閲覧ができなかった為一旦codepenでHTMLとjsの制御の兼ね合いが上手くいくかをテストした。
・文字数制限に関しては一旦200字で仮置きしているが、字数等指定あれば修正する

■特にみて欲しい箇所
・HTMLの閉じタグ(jinja2)等修正したけど合っているか不安なので特にみて欲しい